### PR TITLE
Fixed vehicle despawning/respawning on collision.

### DIFF
--- a/Assets/Environment/Vehicles/Police.prefab
+++ b/Assets/Environment/Vehicles/Police.prefab
@@ -278,7 +278,6 @@ GameObject:
   - component: {fileID: 4333001034710748832}
   - component: {fileID: 7213021772763487256}
   - component: {fileID: 1564399682011387216}
-  - component: {fileID: 4514999533523598848}
   m_Layer: 0
   m_Name: Police
   m_TagString: Traffic
@@ -331,7 +330,9 @@ MonoBehaviour:
     path: {fileID: 0}
   spawner: {fileID: 0}
   rb: {fileID: 1564399682011387216}
-  cleaner: {fileID: 0}
+  cleanupDelay: 5
+  cleanupTimer: 0
+  cleaningUp: 0
 --- !u!54 &1564399682011387216
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -359,20 +360,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!114 &4514999533523598848
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6655375981094646734}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4ae60f630e7c8534e86e88c9f7b2e77b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  delay: 5
-  current: 0
 --- !u!1001 &8430569588627795390
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Environment/Vehicles/Sedan Sport.prefab
+++ b/Assets/Environment/Vehicles/Sedan Sport.prefab
@@ -278,7 +278,6 @@ GameObject:
   - component: {fileID: 4333001034710748832}
   - component: {fileID: 7213021772763487256}
   - component: {fileID: 1564399682011387216}
-  - component: {fileID: 4514999533523598848}
   m_Layer: 0
   m_Name: Sedan Sport
   m_TagString: Traffic
@@ -331,7 +330,9 @@ MonoBehaviour:
     path: {fileID: 0}
   spawner: {fileID: 0}
   rb: {fileID: 1564399682011387216}
-  cleaner: {fileID: 0}
+  cleanupDelay: 5
+  cleanupTimer: 0
+  cleaningUp: 0
 --- !u!54 &1564399682011387216
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -359,20 +360,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!114 &4514999533523598848
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6655375981094646734}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4ae60f630e7c8534e86e88c9f7b2e77b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  delay: 5
-  current: 0
 --- !u!1001 &6950288958414899272
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Environment/Vehicles/Sedan.prefab
+++ b/Assets/Environment/Vehicles/Sedan.prefab
@@ -278,7 +278,6 @@ GameObject:
   - component: {fileID: 4333001034710748832}
   - component: {fileID: 7213021772763487256}
   - component: {fileID: 1564399682011387216}
-  - component: {fileID: 4514999533523598848}
   m_Layer: 0
   m_Name: Sedan
   m_TagString: Traffic
@@ -331,7 +330,9 @@ MonoBehaviour:
     path: {fileID: 0}
   spawner: {fileID: 0}
   rb: {fileID: 1564399682011387216}
-  cleaner: {fileID: 0}
+  cleanupDelay: 5
+  cleanupTimer: 0
+  cleaningUp: 0
 --- !u!54 &1564399682011387216
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -359,20 +360,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!114 &4514999533523598848
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6655375981094646734}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4ae60f630e7c8534e86e88c9f7b2e77b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  delay: 5
-  current: 0
 --- !u!1001 &8194767925841997364
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Environment/Vehicles/Truck.prefab
+++ b/Assets/Environment/Vehicles/Truck.prefab
@@ -278,7 +278,6 @@ GameObject:
   - component: {fileID: 4333001034710748832}
   - component: {fileID: 7213021772763487256}
   - component: {fileID: 1564399682011387216}
-  - component: {fileID: 4514999533523598848}
   m_Layer: 0
   m_Name: Truck
   m_TagString: Traffic
@@ -331,7 +330,9 @@ MonoBehaviour:
     path: {fileID: 0}
   spawner: {fileID: 0}
   rb: {fileID: 1564399682011387216}
-  cleaner: {fileID: 0}
+  cleanupDelay: 5
+  cleanupTimer: 0
+  cleaningUp: 0
 --- !u!54 &1564399682011387216
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -359,20 +360,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!114 &4514999533523598848
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6655375981094646734}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4ae60f630e7c8534e86e88c9f7b2e77b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  delay: 5
-  current: 0
 --- !u!1001 &2740162965099723217
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Environment/Vehicles/Van.prefab
+++ b/Assets/Environment/Vehicles/Van.prefab
@@ -278,7 +278,6 @@ GameObject:
   - component: {fileID: 4333001034710748832}
   - component: {fileID: 7213021772763487256}
   - component: {fileID: 1564399682011387216}
-  - component: {fileID: 4514999533523598848}
   m_Layer: 0
   m_Name: Van
   m_TagString: Traffic
@@ -331,7 +330,9 @@ MonoBehaviour:
     path: {fileID: 0}
   spawner: {fileID: 0}
   rb: {fileID: 1564399682011387216}
-  cleaner: {fileID: 0}
+  cleanupDelay: 5
+  cleanupTimer: 0
+  cleaningUp: 0
 --- !u!54 &1564399682011387216
 Rigidbody:
   m_ObjectHideFlags: 0
@@ -359,20 +360,6 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
---- !u!114 &4514999533523598848
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6655375981094646734}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4ae60f630e7c8534e86e88c9f7b2e77b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  delay: 5
-  current: 0
 --- !u!1001 &8322127593487029595
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Environment/VehiclePathController.cs
+++ b/Assets/Scripts/Environment/VehiclePathController.cs
@@ -7,174 +7,185 @@ using UnityEngine.Splines;
 
 public class VehiclePathController : MonoBehaviour
 {
-    [Header("Vehicle Properties")]
+	[Header( "Vehicle Properties" )]
 
-    /// <summary>
-    /// The distance that the vehicle will move per-second.
-    /// 
-    /// TODO: Add other properties like acceleration, max speed, braking, and so on to give a more 
-    /// realistic sense of movement and allow them to better interact with the world.
-    /// </summary>
-    public float speed = 1f;
-    public float maxSpeed = 4f;
-    public bool isBraking = false;
-    public float brakeSensitvity = 0.1f;
-    public float acceleration = 0.075f;
-    public bool isPathing = true;
-    [Header("Internals")]
+	/// <summary>
+	/// The distance that the vehicle will move per-second.
+	/// 
+	/// TODO: Add other properties like acceleration, max speed, braking, and so on to give a more 
+	/// realistic sense of movement and allow them to better interact with the world.
+	/// </summary>
+	public float speed = 1f;
+	public float maxSpeed = 4f;
+	public bool isBraking = false;
+	public float brakeSensitvity = 0.1f;
+	public float acceleration = 0.075f;
+	public bool isPathing = true;
+	[Header( "Internals" )]
 
-    /// <summary>
-    /// What fraction of the path has the vehicle travelled along, from 0 to 1.
-    /// </summary>
-    public float progress = 0f;
+	/// <summary>
+	/// What fraction of the path has the vehicle travelled along, from 0 to 1.
+	/// </summary>
+	public float progress = 0f;
 
-    /// <summary>
-    /// The tile that this vehicle is currently traversing.
-    /// </summary>
-    public Tile tile;
+	/// <summary>
+	/// The tile that this vehicle is currently traversing.
+	/// </summary>
+	public Tile tile;
 
-    /// <summary>
-    /// The tile path that this vehicle is currently traversing.
-    /// </summary>
-    public TilePath tilePath;
+	/// <summary>
+	/// The tile path that this vehicle is currently traversing.
+	/// </summary>
+	public TilePath tilePath;
 
-    /// <summary>
-    /// Refernce to the vehicle spawner so we can request to be de-spawned.
-    /// </summary>
-    public VehicleSpawner spawner;
-    public Rigidbody rb;
-    public Cleaner cleaner;
+	/// <summary>
+	/// Refernce to the vehicle spawner so we can request to be de-spawned.
+	/// </summary>
+	public VehicleSpawner spawner;
+	public Rigidbody rb;
 
-    public void Start()
-    {
-        UpdateTransform();
-        rb = GetComponent<Rigidbody>();
-        cleaner = GetComponent<Cleaner>();
-    }
+	[Header( "Cleanup" )]
+	public float cleanupDelay = 5f;
+	public float cleanupTimer = 0f;
+	public bool cleaningUp = false;
 
-    public void OnCollisionEnter(Collision collision)
-    {
-        if (!collision.gameObject.CompareTag("Player"))
-            return;
-        
-        this.tag = "Traffic_Collided";
-        rb.isKinematic = false;
-        isPathing = false;
-        cleaner.Activate();
-    }
+	public void Start()
+	{
+		UpdateTransform();
+		rb = GetComponent<Rigidbody>();
+	}
 
-    public void Update()
-    {
-        if (isPathing)
-        {
-            // TODO: Cache distance calculation(s) for the path.
-            var path = GetPath();
-            float pathLength = path.CalculateLength();
-            progress += (speed / pathLength) * Time.deltaTime;
+	public void OnCollisionEnter( Collision collision )
+	{
+		if(!collision.gameObject.CompareTag( "Player" ))
+			return;
 
-            // If we've reached the end of the path, get the next tile in our direction of travel and a path
-            // from it, or despawn if there's no route.
-            if (progress >= 1f)
-            {
-                // Maintain any excess progress into the next tile.
-                // TODO: This will need to be different when using distance not percentage of path.
-                progress -= 1f;
+		this.tag = "Traffic_Collided";
+		rb.isKinematic = false;
+		isPathing = false;
+		cleaningUp = true;
+	}
 
-                // Get the coords of the next tile in our direction.
-                Vector3Int nextTileOffset = new Vector3Int();
-                if (tilePath.end == Direction.North)
-                    nextTileOffset.z = 1;
-                else if (tilePath.end == Direction.South)
-                    nextTileOffset.z = -1;
-                else if (tilePath.end == Direction.East)
-                    nextTileOffset.x = 1;
-                else
-                    nextTileOffset.x = -1;
+	public void Update()
+	{
+		// Handle cleanup.
+		if(cleaningUp)
+		{
+			cleanupTimer += Time.deltaTime;
+			if(cleanupTimer >= cleanupDelay)
+				spawner.DespawnVehicle( this.gameObject );
+		}
 
-                Tile currentTile = tile;
-                Vector3Int nextTileCoords = currentTile.worldCoords + nextTileOffset;
+		if(isPathing)
+		{
+			// TODO: Cache distance calculation(s) for the path.
+			var path = GetPath();
+			float pathLength = path.CalculateLength();
+			progress += (speed / pathLength) * Time.deltaTime;
 
-                // Get the next tile object or despawn if there isn't one (reached the edge of the world).
-                Tile nextTile = spawner.world.GetTile(nextTileCoords);
-                if (nextTile == null)
-                {
-                    spawner.DespawnVehicle(gameObject);
-                    return;
-                }
+			// If we've reached the end of the path, get the next tile in our direction of travel and a path
+			// from it, or despawn if there's no route.
+			if(progress >= 1f)
+			{
+				// Maintain any excess progress into the next tile.
+				// TODO: This will need to be different when using distance not percentage of path.
+				progress -= 1f;
 
-                // Get an appropriate tile path for us to follow.
-                Direction invertedDirection;
-                if (tilePath.end == Direction.North)
-                    invertedDirection = Direction.South;
-                else if (tilePath.end == Direction.South)
-                    invertedDirection = Direction.North;
-                else if (tilePath.end == Direction.East)
-                    invertedDirection = Direction.West;
-                else
-                    invertedDirection = Direction.East;
+				// Get the coords of the next tile in our direction.
+				Vector3Int nextTileOffset = new Vector3Int();
+				if(tilePath.end == Direction.North)
+					nextTileOffset.z = 1;
+				else if(tilePath.end == Direction.South)
+					nextTileOffset.z = -1;
+				else if(tilePath.end == Direction.East)
+					nextTileOffset.x = 1;
+				else
+					nextTileOffset.x = -1;
 
-                TilePath nextTilePath = nextTile.RandomTilePath(invertedDirection);
+				Tile currentTile = tile;
+				Vector3Int nextTileCoords = currentTile.worldCoords + nextTileOffset;
 
-                if (nextTilePath == null)
-                {
-                    spawner.DespawnVehicle(gameObject);
-                    return;
-                }
+				// Get the next tile object or despawn if there isn't one (reached the edge of the world).
+				Tile nextTile = spawner.world.GetTile( nextTileCoords );
+				if(nextTile == null)
+				{
+					spawner.DespawnVehicle( gameObject );
+					return;
+				}
 
-                // Set our tile and path references to the next things and off we go.
-                tile = nextTile;
-                tilePath = nextTilePath;
-            }
+				// Get an appropriate tile path for us to follow.
+				Direction invertedDirection;
+				if(tilePath.end == Direction.North)
+					invertedDirection = Direction.South;
+				else if(tilePath.end == Direction.South)
+					invertedDirection = Direction.North;
+				else if(tilePath.end == Direction.East)
+					invertedDirection = Direction.West;
+				else
+					invertedDirection = Direction.East;
 
-            UpdateTransform();
-        }
-    }
+				TilePath nextTilePath = nextTile.RandomTilePath( invertedDirection );
 
-    /// <summary>
-    /// Updates the position and rotation of the vehicle based on its progress along the path.
-    /// </summary>
-    public void UpdateTransform()
-    {
-        var path = GetPath();
+				if(nextTilePath == null)
+				{
+					spawner.DespawnVehicle( gameObject );
+					return;
+				}
 
-        float3 position;
-        float3 tangent;
-        float3 up;
+				// Set our tile and path references to the next things and off we go.
+				tile = nextTile;
+				tilePath = nextTilePath;
+			}
 
-        path.Evaluate(Mathf.Clamp(progress, 0f, 1f), out position, out tangent, out up);
-        Vector3 forward = Vector3.Cross(Vector3.up, tangent);
+			UpdateTransform();
+		}
+	}
 
-        transform.position = position;
-        transform.rotation = Quaternion.LookRotation(forward, Vector3.up) * Quaternion.Euler(new Vector3(0f, -90f, 0f));
-    }
+	/// <summary>
+	/// Updates the position and rotation of the vehicle based on its progress along the path.
+	/// </summary>
+	public void UpdateTransform()
+	{
+		var path = GetPath();
 
-    /// <summary>
-    /// We often want the SplineContainer component from the tile path, this makes getting that a 
-    /// fraction easier.
-    /// </summary>
-    /// <returns>The SplineContainer for the current tile path.</returns>
-    SplineContainer GetPath()
-    {
-        GameObject pathObject = tilePath.path;
-        return pathObject.GetComponent<SplineContainer>();
-    }
+		float3 position;
+		float3 tangent;
+		float3 up;
 
-    private void FixedUpdate()
-    {
-        if (this.isBraking == true)
-        {
-            if (speed > 0)
-            {
-                speed = Mathf.Max(speed - brakeSensitvity, 0f);
-            }
+		path.Evaluate( Mathf.Clamp( progress, 0f, 1f ), out position, out tangent, out up );
+		Vector3 forward = Vector3.Cross( Vector3.up, tangent );
 
-        }
-        else
-        {
-            if (speed < maxSpeed)
-            {
-                speed = speed + acceleration;
-            }
-        }
-    }
+		transform.position = position;
+		transform.rotation = Quaternion.LookRotation( forward, Vector3.up ) * Quaternion.Euler( new Vector3( 0f, -90f, 0f ) );
+	}
+
+	/// <summary>
+	/// We often want the SplineContainer component from the tile path, this makes getting that a 
+	/// fraction easier.
+	/// </summary>
+	/// <returns>The SplineContainer for the current tile path.</returns>
+	SplineContainer GetPath()
+	{
+		GameObject pathObject = tilePath.path;
+		return pathObject.GetComponent<SplineContainer>();
+	}
+
+	private void FixedUpdate()
+	{
+		if(this.isBraking == true)
+		{
+			if(speed > 0)
+			{
+				speed = Mathf.Max( speed - brakeSensitvity, 0f );
+			}
+
+		}
+		else
+		{
+			if(speed < maxSpeed)
+			{
+				speed = speed + acceleration;
+			}
+		}
+	}
 }

--- a/Assets/Scripts/Environment/VehicleSpawner.cs
+++ b/Assets/Scripts/Environment/VehicleSpawner.cs
@@ -76,6 +76,8 @@ public class VehicleSpawner : MonoBehaviour
 		// Get a Tile Path from the tile, which we'll have the vehicle follow.
 		TilePath tilePath = tile.RandomTilePath();
 
+		Debug.Log( $"Spawning Vehicle: {tile.worldCoords.x},{tile.worldCoords.z}" );
+
 		if(tilePath != null)
 		{
 			// Spawn the Vehicle and set it on the tile path.
@@ -116,6 +118,8 @@ public class VehicleSpawner : MonoBehaviour
 	/// <param name="vehicleObject">The game object of the vehicle to despawn.</param>
 	public void DespawnVehicle( GameObject vehicleObject )
 	{
+		Debug.Log($"Despawning Vehicle: {vehicleObject.name}");
+
 		Destroy( vehicleObject );
 		SpawnVehicle();
 	}
@@ -132,7 +136,7 @@ public class VehicleSpawner : MonoBehaviour
 				var vehicle = vehicleObject.GetComponent<VehiclePathController>();
 				if(vehicle != null)
 				{
-					if(tile != vehicle.tile)
+					if(tile == vehicle.tile)
 						return true;
 				}
 			}


### PR DESCRIPTION
After collision we were using the normal cleaner script, which would correctly remove the vehicle but not call the spawner to spawn a new one.

So vehicles have their own timer and when it hits the limit they call the spawner to remove the vehicle, which also spawns a new one in.